### PR TITLE
Stabilize hascoapi docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-fuseki/
+#fuseki/
 fuseki-yasgui/
-conf/application.conf
+#conf/application.conf
 conf/hascoapi-docker.conf
 conf/hascoapi.conf
 logs

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,7 +1,7 @@
 FROM hansidm/fuseki:4.7.0
 
 RUN mkdir /fuseki/configuration
-COPY fuseki-jetty.xml hascoapi_assembler.ttl /fuseki/configuration/
+COPY --chown=fuseki:fuseki fuseki-jetty.xml hascoapi_assembler.ttl /fuseki/configuration/
 
 CMD [ \
     "--config=/fuseki/configuration/hascoapi_assembler.ttl", \


### PR DESCRIPTION
1. Change the **fuseki/Dockerfile** to associate the fuseki:fuseki user group permissions at the files: **fuseki-jetty.xml** and **hascoapi_assembler.ttl**.

2. Comment the **application.conf** and **fuseki/** from gitignore.